### PR TITLE
Fix "Peek" typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ func main() {
     q.Offer(123)
 
     // return head queue but not remove
-    head := q.Peak()
+    head := q.Peek()
     fmt.Println(head)
 
     // remove and return head queue

--- a/queue/README.md
+++ b/queue/README.md
@@ -23,7 +23,7 @@ func main() {
     polled := q.Poll()
 
     // return head queue but not remove
-    head := q.Peak()
+    head := q.Peek()
 }
 ```
 


### PR DESCRIPTION
The method name is `Peek` but examples on README spell it as `Peak`.

Signed-off-by: Yuki Okushi <jtitor@2k36.org>